### PR TITLE
Add install and CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 Tools to compare database schemas and table rows.
 
+# Installation
+
+Install `python-dbdiff` from PyPI:
+
+```bash
+pip install python-dbdiff
+```
+
+This will install two command line tools named `schemadiff` and `datadiff`.
+
 # General Architecture
 
 schema/__init__.py has a database-agnostic schema framework:
@@ -24,6 +34,20 @@ The main.py script imports the schema for source and destination database and ou
 
 The maindata.py script compares the tables rows in the source and destination databases.  It depends on the schema
 framework to determine how to construct primary key objects for each table.
+
+# CLI Usage
+
+After installation the `schemadiff` and `datadiff` commands become available. Run
+`--help` on either command to see all options. The most common invocations are:
+
+```
+schemadiff diffschema DB1_ENV_FILE DB2_ENV_FILE [--uppercase|--lowercase]
+schemadiff diffprocs DB1_ENV_FILE DB2_ENV_FILE
+schemadiff tablelist DB_ENV_FILE [--uppercase|--lowercase]
+
+datadiff tablediff DB1_ENV_FILE DB2_ENV_FILE [TABLE ...] [--uppercase|--lowercase]
+datadiff tablereport DB_ENV_FILE [TABLE ...]
+```
 
 
 


### PR DESCRIPTION
## Summary
- document installation steps via pip
- describe how to use the `schemadiff` and `datadiff` commands

## Testing
- `pytest -q` *(fails: No module named 'mysql')*