### PR TITLE
Clean up pytest path handling

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-pythonpath = src
 testpaths = tests

--- a/src/dbdiff/schema/mysql.py
+++ b/src/dbdiff/schema/mysql.py
@@ -4,7 +4,11 @@
 
 from typing import Dict, List
 from . import Constraint, Database, Table, Column, Index
-import mysql.connector
+
+try:
+    import mysql.connector  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    mysql = None
 
 # Sample record from information_schema.tables
 # {'TABLE_CATALOG': 'def',
@@ -87,6 +91,8 @@ class MySQLDatabase(Database):
         super().__init__(name)
 
     def connect(self, **kwargs):
+        if mysql is None:  # pragma: no cover - optional dependency
+            raise ImportError("mysql.connector is required for database connections")
         self.conn = mysql.connector.connect(**kwargs)
 
     def fetch_table_rows(self, tablename: str, where: str = None, orderby: str = None) -> List[Dict]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+# Add project src directory to sys.path for tests
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)


### PR DESCRIPTION
## Summary
- drop pythonpath usage from pytest.ini
- stub optional `mysql.connector` dependency so tests don't fail when it's missing
- add a test `conftest.py` to inject the `src` directory on `sys.path`

## Testing
- `pytest -q`